### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://laxmimanoj.visualstudio.com/446b4149-3ab2-4a0b-9441-f8f0d4ea8f12/b498b057-7554-4a7e-8530-344dfa03ee81/_apis/work/boardbadge/d92d38bd-2ae0-4515-83a2-695d1481e8ff)](https://laxmimanoj.visualstudio.com/446b4149-3ab2-4a0b-9441-f8f0d4ea8f12/_boards/board/t/b498b057-7554-4a7e-8530-344dfa03ee81/Microsoft.RequirementCategory)
 # docs
 A set of design docs, notes and ideas


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://laxmimanoj.visualstudio.com/446b4149-3ab2-4a0b-9441-f8f0d4ea8f12/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.